### PR TITLE
Hide counter when map is unranked for BeatLeader

### DIFF
--- a/PPPredictor/Data/PPPStarRating.cs
+++ b/PPPredictor/Data/PPPStarRating.cs
@@ -58,8 +58,9 @@ namespace PPPredictor.Data
             _modifierValues = beatLeaderDifficulty.modifierValues ?? null;
         }
 
-        internal PPPStarRating(double mulitplier, double accRating, double passRating, double techRating)
+        internal PPPStarRating(double mulitplier, double accRating, double passRating, double techRating, bool? rankedBeatLeader = null)
         {
+            _rankedBeatLeader = rankedBeatLeader;
             _multiplier = mulitplier;
             _accRating = accRating;
             _passRating = passRating;

--- a/PPPredictor/Data/PPPStarRating.cs
+++ b/PPPredictor/Data/PPPStarRating.cs
@@ -58,9 +58,8 @@ namespace PPPredictor.Data
             _modifierValues = beatLeaderDifficulty.modifierValues ?? null;
         }
 
-        internal PPPStarRating(double mulitplier, double accRating, double passRating, double techRating, bool? rankedBeatLeader = null)
+        internal PPPStarRating(double mulitplier, double accRating, double passRating, double techRating)
         {
-            _rankedBeatLeader = rankedBeatLeader;
             _multiplier = mulitplier;
             _accRating = accRating;
             _passRating = passRating;

--- a/PPPredictor/Data/PPPStarRating.cs
+++ b/PPPredictor/Data/PPPStarRating.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 using Newtonsoft.Json;
+using PPPredictor.Utilities;
 using static PPPredictor.Data.LeaderBoardDataTypes.BeatLeaderDataTypes;
 
 namespace PPPredictor.Data
@@ -13,9 +14,12 @@ namespace PPPredictor.Data
         private double _passRating = 0;
         private double _accRating = 0;
         private double _techRating = 0;
+        private bool? _rankedBeatLeader = null;
         private Dictionary<string, double> _modifiersRating = new Dictionary<string, double>();
         private Dictionary<string, double> _modifierValues = new Dictionary<string, double>();
-
+        
+        [DefaultValue(null)]
+        public bool? RankedBeatLeader{ get => _rankedBeatLeader; set => _rankedBeatLeader = value; }
         [DefaultValue(0d)]
         public double Stars { get => _stars; set => _stars = value; }
         [DefaultValue(0d)]
@@ -45,6 +49,7 @@ namespace PPPredictor.Data
 
         internal PPPStarRating(BeatLeaderDifficulty beatLeaderDifficulty)
         {
+            _rankedBeatLeader = beatLeaderDifficulty.status == (int)BeatLeaderDifficultyStatus.ranked;
             _predictedAcc = beatLeaderDifficulty.predictedAcc.GetValueOrDefault();
             _passRating = beatLeaderDifficulty.passRating.GetValueOrDefault();
             _accRating = beatLeaderDifficulty.accRating.GetValueOrDefault();
@@ -63,7 +68,11 @@ namespace PPPredictor.Data
 
         internal bool IsRanked()
         {
-            return _predictedAcc > 0 || _passRating > 0 || _accRating > 0 || _techRating > 0 || _stars > 0;
+            if(_rankedBeatLeader == false){
+                return false;
+            }
+
+            return _predictedAcc > 0 || _passRating > 0 || _accRating > 0 || _techRating > 0 || _stars > 0;      
         }
     }
 }

--- a/UnitTests/Data/TestPPPStarRating.cs
+++ b/UnitTests/Data/TestPPPStarRating.cs
@@ -1,4 +1,5 @@
 ﻿using PPPredictor.Data;
+using PPPredictor.Utilities;
 using static PPPredictor.Data.LeaderBoardDataTypes.BeatLeaderDataTypes;
 
 namespace UnitTests.Data
@@ -69,13 +70,15 @@ namespace UnitTests.Data
             Assert.IsNull(starRating.ModifiersRating);
             Assert.IsNull(starRating.ModifierValues);
 
+            //Unranked
             beatLeaderDifficulty = new BeatLeaderDifficulty() {
                 predictedAcc = predictedAcc,
                 passRating = passRating,
                 accRating = accRating,
                 techRating = techRating,
                 modifiersRating = new Dictionary<string, double>(),
-                modifierValues = new Dictionary<string, double>()
+                modifierValues = new Dictionary<string, double>(),
+                status = (int)BeatLeaderDifficultyStatus.unranked
             };
             starRating = new PPPStarRating(beatLeaderDifficulty);
 
@@ -86,6 +89,29 @@ namespace UnitTests.Data
             Assert.AreEqual(starRating.TechRating, techRating);
             Assert.IsNotNull(starRating.ModifiersRating);
             Assert.IsNotNull(starRating.ModifierValues);
+            Assert.IsFalse(starRating.IsRanked()); //Status is unranked, so should be unranked
+
+            //Ranked
+            beatLeaderDifficulty = new BeatLeaderDifficulty()
+            {
+                predictedAcc = predictedAcc,
+                passRating = passRating,
+                accRating = accRating,
+                techRating = techRating,
+                modifiersRating = new Dictionary<string, double>(),
+                modifierValues = new Dictionary<string, double>(),
+                status = (int)BeatLeaderDifficultyStatus.ranked
+            };
+            starRating = new PPPStarRating(beatLeaderDifficulty);
+
+            Assert.AreEqual(starRating.Stars, 0);
+            Assert.AreEqual(starRating.PredictedAcc, predictedAcc);
+            Assert.AreEqual(starRating.PassRating, passRating);
+            Assert.AreEqual(starRating.AccRating, accRating);
+            Assert.AreEqual(starRating.TechRating, techRating);
+            Assert.IsNotNull(starRating.ModifiersRating);
+            Assert.IsNotNull(starRating.ModifierValues);
+            Assert.IsTrue(starRating.IsRanked()); //Status is ranked, so should be ranked
         }
 
         [TestMethod]


### PR DESCRIPTION
This adjusts the IsRanked determination for BeatLeader map difficulties to take the difficulty's status into account.

Added a couple tests to check its implementation.

Let me know if you need me to adjust anything or have any questions.